### PR TITLE
Cast to avoid "incompatible function pointer types" error

### DIFF
--- a/qemu/unicorn_common.h
+++ b/qemu/unicorn_common.h
@@ -136,7 +136,7 @@ static inline void uc_common_init(struct uc_struct* uc)
     uc->target_page = target_page_init;
     uc->softfloat_initialize = softfloat_init;
     uc->tcg_flush_tlb = tcg_flush_softmmu_tlb;
-    uc->memory_map_io = memory_map_io;
+    uc->memory_map_io = (uc_memory_map_io_t)memory_map_io;
     uc->set_tlb = uc_set_tlb;
     uc->memory_mapping = find_memory_mapping;
     uc->memory_filter_subregions = memory_region_filter_subregions;


### PR DESCRIPTION
Ubuntu Noble에서 compile이 되지 않는 문제를 수정합니다.


```
In file included from /home/ubuntu/kernel/npu-tools/crates/npu-virtual-platform/unicorn/qemu/target/arm/unicorn_aarch64.c:10:
/home/ubuntu/kernel/npu-tools/crates/npu-virtual-platform/unicorn/qemu/unicorn_common.h: In function ‘uc_common_init’:
/home/ubuntu/kernel/npu-tools/crates/npu-virtual-platform/unicorn/qemu/unicorn_common.h:139:23: warning: assignment to ‘uc_memory_map_io_t’ {aka ‘MemoryRegion * (*)(struct uc_struct *, long unsigned int,  long unsigned int,  enum uc_tx_result (*)(struct uc_struct *, void *, struct uc_mmio_tx *), void *)’} from incompatible pointer type ‘MemoryRegion * (*)(struct uc_struct *, ram_addr_t,  size_t,  void *, void *)’ {aka ‘MemoryRegion * (*)(struct uc_struct *, long unsigned int,  long unsigned int,  void *, void *)’} [-Wincompatible-pointer-types]
  139 |     uc->memory_map_io = memory_map_io;
```

`incompatible-pointer-types`가 compiler에서 hard error로 변경된거 같습니다.