### PR TITLE
Run configure only when it has changed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -362,12 +362,27 @@ else()
     set(TARGET_LIST "${TARGET_LIST} ")
 
     # GEN config-host.mak & target directories
-    execute_process(COMMAND sh ${CMAKE_CURRENT_SOURCE_DIR}/qemu/configure
-        --cc=${CMAKE_C_COMPILER}
-        ${EXTRA_CFLAGS}
-        ${TARGET_LIST}
-        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-    )
+    if(NOT EXISTS "${CMAKE_BINARY_DIR}/config-host.mak")
+        execute_process(COMMAND sh ${CMAKE_CURRENT_SOURCE_DIR}/qemu/configure
+            --cc=${CMAKE_C_COMPILER}
+            ${EXTRA_CFLAGS}
+            ${TARGET_LIST}
+            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+        )
+    else()
+        file(TIMESTAMP ${CMAKE_CURRENT_SOURCE_DIR}/qemu/configure CONFIGURE_TIMESTAMP %s)
+        file(TIMESTAMP ${CMAKE_BINARY_DIR}/config-host.mak CONFIG_MAK_TIMESTAMP %s)
+        # Only run configure when configure has changed after config-host.mak generation
+        if(CONFIG_MAK_TIMESTAMP LESS CONFIGURE_TIMESTAMP)
+            message("Overwriting ${CMAKE_BINARY_DIR}/config-host.mak")
+            execute_process(COMMAND sh ${CMAKE_CURRENT_SOURCE_DIR}/qemu/configure
+                --cc=${CMAKE_C_COMPILER}
+                ${EXTRA_CFLAGS}
+                ${TARGET_LIST}
+                WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+            )
+        endif()
+    endif()
     # Do not regenerate config if unchanged
     if(NOT EXISTS "${CMAKE_BINARY_DIR}/config-host.h")
         execute_process(COMMAND sh ${CMAKE_CURRENT_SOURCE_DIR}/qemu/scripts/create_config


### PR DESCRIPTION
* unicorn build 할때마다 qemu configure를 실행해서 시간이 걸립니다
* configure가 수정되었을 때만 실행하게 변경합니다
* qemu main repo에서도 이렇게 설정되어 있는데 unicorn cmake에서는 누락되어 있습니다
    * https://www.qemu.org/docs/master/devel/build-system.html
    * https://github.com/qemu/qemu/blob/master/Makefile